### PR TITLE
Improve: lazy-load SVG icons

### DIFF
--- a/as.js
+++ b/as.js
@@ -1,0 +1,76 @@
+import { daysToMonths, monthsToDays } from './bubble';
+import { normalizeUnits } from '../units/aliases';
+
+export function as(units) {
+    if (!this.isValid()) {
+        return NaN;
+    }
+    var days,
+        months,
+        milliseconds = this._milliseconds;
+
+    units = normalizeUnits(units);
+
+    if (units === 'month' || units === 'quarter' || units === 'year') {
+        days = this._days + milliseconds / 864e5;
+        months = this._months + daysToMonths(days);
+        switch (units) {
+            case 'month':
+                return months;
+            case 'quarter':
+                return months / 3;
+            case 'year':
+                return months / 12;
+        }
+    } else {
+        // handle milliseconds separately because of floating point math errors (issue #1867)
+        days = this._days + Math.round(monthsToDays(this._months));
+        switch (units) {
+            case 'week':
+                return days / 7 + milliseconds / 6048e5;
+            case 'day':
+                return days + milliseconds / 864e5;
+            case 'hour':
+                return days * 24 + milliseconds / 36e5;
+            case 'minute':
+                return days * 1440 + milliseconds / 6e4;
+            case 'second':
+                return days * 86400 + milliseconds / 1000;
+            // Math.floor prevents floating point math errors here
+            case 'millisecond':
+                return Math.floor(days * 864e5) + milliseconds;
+            default:
+                throw new Error('Unknown unit ' + units);
+        }
+    }
+}
+
+function makeAs(alias) {
+    return function () {
+        return this.as(alias);
+    };
+}
+
+var asMilliseconds = makeAs('ms'),
+    asSeconds = makeAs('s'),
+    asMinutes = makeAs('m'),
+    asHours = makeAs('h'),
+    asDays = makeAs('d'),
+    asWeeks = makeAs('w'),
+    asMonths = makeAs('M'),
+    asQuarters = makeAs('Q'),
+    asYears = makeAs('y'),
+    valueOf = asMilliseconds;
+
+export {
+    asMilliseconds,
+    asSeconds,
+    asMinutes,
+    asHours,
+    asDays,
+    asWeeks,
+    asMonths,
+    asQuarters,
+    asYears,
+    valueOf,
+};


### PR DESCRIPTION
Reduce initial bundle size and improve first contentful paint by lazy-loading the SVG icon set. Replace direct icon imports with dynamic imports in the Icon component, add a lightweight fallback spinner, and update unit tests/Storybook to reflect the change.