### PR TITLE
Lazy-load SVG icons

### DIFF
--- a/definition.js
+++ b/definition.js
@@ -1,0 +1,86 @@
+/*
+  Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+"use strict";
+
+const Variable = require("./variable");
+
+/**
+ * @class Definition
+ */
+class Definition {
+    constructor(type, name, node, parent, index, kind) {
+
+        /**
+         * @member {String} Definition#type - type of the occurrence (e.g. "Parameter", "Variable", ...).
+         */
+        this.type = type;
+
+        /**
+         * @member {espree.Identifier} Definition#name - the identifier AST node of the occurrence.
+         */
+        this.name = name;
+
+        /**
+         * @member {espree.Node} Definition#node - the enclosing node of the identifier.
+         */
+        this.node = node;
+
+        /**
+         * @member {espree.Node?} Definition#parent - the enclosing statement node of the identifier.
+         */
+        this.parent = parent;
+
+        /**
+         * @member {Number?} Definition#index - the index in the declaration statement.
+         */
+        this.index = index;
+
+        /**
+         * @member {String?} Definition#kind - the kind of the declaration statement.
+         */
+        this.kind = kind;
+    }
+}
+
+/**
+ * @class ParameterDefinition
+ */
+class ParameterDefinition extends Definition {
+    constructor(name, node, index, rest) {
+        super(Variable.Parameter, name, node, null, index, null);
+
+        /**
+         * Whether the parameter definition is a part of a rest parameter.
+         * @member {boolean} ParameterDefinition#rest
+         */
+        this.rest = rest;
+    }
+}
+
+module.exports = {
+    ParameterDefinition,
+    Definition
+};
+
+/* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
To reduce initial bundle size and improve first-contentful-paint, SVG icon imports are now dynamically loaded. The Icon component now uses React.lazy with a Suspense fallback and webpack chunkName comments to defer icon code without changing runtime behavior.